### PR TITLE
Pipewire client: disconnect-on-idle support

### DIFF
--- a/client/player/pipewire_player.cpp
+++ b/client/player/pipewire_player.cpp
@@ -24,6 +24,7 @@
 #include "common/aixlog.hpp"
 #include "common/snap_exception.hpp"
 #include "common/str_compat.hpp"
+#include "common/time_defs.hpp"
 #include "common/utils/string_utils.hpp"
 
 // 3rd party headers
@@ -188,7 +189,8 @@ std::vector<PcmDevice> PipeWirePlayer::pcm_list(const std::string& parameter)
 
 
 PipeWirePlayer::PipeWirePlayer(boost::asio::io_context& io_context, const ClientSettings::Player& settings, std::shared_ptr<Stream> stream)
-    : Player(io_context, settings, std::move(stream)), pw_main_loop_(nullptr), pw_stream_(nullptr), node_latency_(std::nullopt)
+    : Player(io_context, settings, std::move(stream)), pw_main_loop_(nullptr), pw_stream_(nullptr), node_latency_(std::nullopt), idle_threshold_(5s),
+      last_chunk_tick_(0), stream_active_(true)
 {
     LOG(DEBUG, LOG_TAG) << "Pipewire player\n";
 
@@ -196,6 +198,12 @@ PipeWirePlayer::PipeWirePlayer(boost::asio::io_context& io_context, const Client
 
     if (params.find("buffer_time") != params.end())
         node_latency_ = std::chrono::milliseconds(std::max(cpt::stoi(params["buffer_time"].front()), 10));
+
+    if (params.find("idle_threshold_ms") != params.end())
+    {
+        idle_threshold_ = std::chrono::milliseconds(std::max(cpt::stoi(params["idle_threshold_ms"].front()), 0));
+        LOG(INFO, LOG_TAG) << "idle_threshold_ms: " << idle_threshold_.count() << " (0 = disabled)\n";
+    }
 }
 
 
@@ -258,18 +266,27 @@ void PipeWirePlayer::start()
 void PipeWirePlayer::stop()
 {
     LOG(INFO, LOG_TAG) << "Stop\n";
-    Player::stop();
+
+    // Don't call Player::stop() — its `if (active_)` guard couples set-and-join, which
+    // forces the wrong order for us (we need active_=false BEFORE the loop is quit so
+    // the worker's re-init path is skipped, but join must still happen). Replicate its
+    // 4-line body with the right ordering.
+    if (active_)
+    {
+        active_ = false;
+        if (pw_main_loop_)
+            pw_main_loop_quit(pw_main_loop_);
+        if (playerThread_.joinable())
+            playerThread_.join();
+    }
     uninitPipewire();
 }
 
 
 void PipeWirePlayer::onProcess()
 {
-    if (!active_)
-    {
-        pw_main_loop_quit(pw_main_loop_);
-        return;
-    }
+    // Note: shutdown is handled directly by stop() which calls pw_main_loop_quit;
+    // we don't need to poll active_ here.
 
     struct pw_buffer* b;
     if ((b = pw_stream_dequeue_buffer(pw_stream_)) == nullptr)
@@ -335,10 +352,27 @@ void PipeWirePlayer::onProcess()
     // LOG(TRACE, LOG_TAG) << "Delay: " << time.delay << ", rate: " << time.rate.num << "/" << time.rate.denom << ", ms: " << delay_us / 1000 << "\n";
     if (!stream_->getPlayerChunkOrSilence(dst, chronos::usec(delay_us), n_frames))
     {
-        // LOG(DEBUG, LOG_TAG) << "Failed to get chunk. Playing silence.\n";
+        // No chunk available; playing silence. If we've been idle long enough,
+        // suspend the stream so the sink can power down its DAC.
+        if (idle_threshold_ > 0s && stream_active_.load() && chronos::getTickCount() - last_chunk_tick_.load() > idle_threshold_.count())
+        {
+            LOG(INFO, LOG_TAG) << "No chunk for " << idle_threshold_.count() << "ms, suspending stream\n";
+            stream_active_ = false;
+            // pw_stream_set_active and starting the watcher thread must run on the main
+            // loop, not from this on_process callback (which runs on the data/realtime loop).
+            pw_loop_invoke(pw_main_loop_get_loop(pw_main_loop_), [](struct spa_loop*, bool, uint32_t, const void*, size_t, void* user_data) -> int
+            {
+                auto* self = static_cast<PipeWirePlayer*>(user_data);
+                if (self->pw_stream_)
+                    pw_stream_set_active(self->pw_stream_, false);
+                self->startWatcher();
+                return 0;
+            }, 0, nullptr, 0, false, this);
+        }
     }
     else
     {
+        last_chunk_tick_ = chronos::getTickCount();
         adjustVolume(reinterpret_cast<char*>(dst), n_frames);
     }
 
@@ -524,15 +558,23 @@ void PipeWirePlayer::initPipewire()
         uninitPipewire();
         throw SnapException("Failed to connect PipeWire stream: " + std::string(spa_strerror(res)));
     }
+
+    // Reset idle-suspend state so we don't go idle on startup before any chunks arrive
+    last_chunk_tick_ = chronos::getTickCount();
+    stream_active_ = true;
 }
 
 void PipeWirePlayer::uninitPipewire()
 {
+    // Stop the watcher first so no pending pw_loop_invoke fires after we've torn things down
+    stopWatcher();
+
     if (pw_stream_)
     {
-        pw_stream_disconnect(pw_stream_);
-        pw_stream_destroy(pw_stream_);
-        pw_stream_ = nullptr;
+        pw_stream* tmp = pw_stream_;
+        pw_stream_ = nullptr; // null first so any in-flight onChunkWakeup is a no-op
+        pw_stream_disconnect(tmp);
+        pw_stream_destroy(tmp);
     }
 
     if (pw_main_loop_)
@@ -540,6 +582,54 @@ void PipeWirePlayer::uninitPipewire()
         pw_main_loop_destroy(pw_main_loop_);
         pw_main_loop_ = nullptr;
     }
+}
+
+void PipeWirePlayer::startWatcher()
+{
+    std::lock_guard<std::mutex> lock(watcher_mutex_);
+    if (watcher_thread_.joinable())
+        watcher_thread_.join();
+
+    watcher_thread_ = std::thread([this]()
+    {
+        LOG(DEBUG, LOG_TAG) << "Watcher thread started\n";
+        // 1s timeout is just for periodic shutdown checks; condition variable in
+        // Stream::waitForChunk wakes us within microseconds of an actual chunk.
+        while (active_ && !stream_active_.load())
+        {
+            if (stream_->waitForChunk(1000ms))
+            {
+                LOG(DEBUG, LOG_TAG) << "Watcher: chunk available, scheduling wakeup on main loop\n";
+                pw_loop_invoke(pw_main_loop_get_loop(pw_main_loop_), [](struct spa_loop*, bool, uint32_t, const void*, size_t, void* user_data) -> int
+                {
+                    auto* self = static_cast<PipeWirePlayer*>(user_data);
+                    self->onChunkWakeup();
+                    return 0;
+                }, 0, nullptr, 0, false, this);
+                return;
+            }
+            // Timeout — loop and re-check active_ / stream_active_
+        }
+        LOG(DEBUG, LOG_TAG) << "Watcher thread exiting without firing wakeup\n";
+    });
+}
+
+void PipeWirePlayer::stopWatcher()
+{
+    std::lock_guard<std::mutex> lock(watcher_mutex_);
+    if (watcher_thread_.joinable())
+        watcher_thread_.join();
+}
+
+void PipeWirePlayer::onChunkWakeup()
+{
+    if (!pw_stream_)
+        return; // stream torn down between watcher's invoke and us being scheduled
+
+    LOG(INFO, LOG_TAG) << "Chunk available, resuming stream\n";
+    last_chunk_tick_ = chronos::getTickCount();
+    stream_active_ = true;
+    pw_stream_set_active(pw_stream_, true);
 }
 
 void PipeWirePlayer::setHardwareVolume(const Volume& volume)

--- a/client/player/pipewire_player.hpp
+++ b/client/player/pipewire_player.hpp
@@ -29,10 +29,13 @@
 #include <pipewire/stream.h>
 
 // standard headers
+#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <thread>
 
 namespace player
 {
@@ -71,6 +74,16 @@ private:
     void worker() override;
     bool needsThread() const override;
 
+    /// Spawn the chunk-watcher thread that wakes the stream when audio resumes.
+    /// Called on the main-loop thread when going idle.
+    void startWatcher();
+    /// Stop and join the watcher thread (if running).
+    /// Called on shutdown or when reactivating the stream.
+    void stopWatcher();
+    /// Reactivate the suspended stream. Scheduled on the main-loop thread by the watcher
+    /// (via pw_loop_invoke) when a chunk arrives.
+    void onChunkWakeup();
+
     // PipeWire structures
     struct pw_main_loop* pw_main_loop_;
     struct pw_stream* pw_stream_;
@@ -79,6 +92,17 @@ private:
     struct pw_stream_events stream_events_;
 
     std::optional<std::chrono::milliseconds> node_latency_;
+
+    // Idle suspend: deactivate stream after no chunks for this long. 0 = disabled.
+    std::chrono::milliseconds idle_threshold_;
+    /// Tick count of last received real (non-silence) chunk
+    std::atomic<long> last_chunk_tick_;
+    /// True iff pw_stream_ is currently set_active(true)
+    std::atomic<bool> stream_active_;
+    /// Watcher thread that blocks on Stream::waitForChunk while suspended
+    std::thread watcher_thread_;
+    /// Guards watcher_thread_ join/spawn
+    std::mutex watcher_mutex_;
 };
 
 } // namespace player

--- a/client/player/pulse_player.cpp
+++ b/client/player/pulse_player.cpp
@@ -138,14 +138,19 @@ vector<PcmDevice> PulsePlayer::pcm_list(const std::string& parameter)
 
 
 PulsePlayer::PulsePlayer(boost::asio::io_context& io_context, const ClientSettings::Player& settings, std::shared_ptr<Stream> stream)
-    : Player(io_context, settings, std::move(stream)), latency_(BUFFER_TIME), last_chunk_tick_(0), pa_ml_(nullptr), pa_ctx_(nullptr), playstream_(nullptr),
-      proplist_(nullptr), server_(std::nullopt)
+    : Player(io_context, settings, std::move(stream)), latency_(BUFFER_TIME), last_chunk_tick_(0), idle_threshold_(5s), pa_ml_(nullptr), pa_ctx_(nullptr),
+      playstream_(nullptr), proplist_(nullptr), server_(std::nullopt)
 {
     auto params = utils::string::split_pairs_to_container<std::vector<std::string>>(settings.parameter, ',', '=');
     if (params.find("buffer_time") != params.end())
         latency_ = std::chrono::milliseconds(std::max(cpt::stoi(params["buffer_time"].front()), 10));
     if (params.find("server") != params.end())
         server_ = params["server"].front();
+    if (params.find("idle_threshold_ms") != params.end())
+    {
+        idle_threshold_ = std::chrono::milliseconds(std::max(cpt::stoi(params["idle_threshold_ms"].front()), 0));
+        LOG(INFO, LOG_TAG) << "idle_threshold_ms: " << idle_threshold_.count() << " (0 = disabled)\n";
+    }
     properties_[PA_PROP_MEDIA_ROLE] = "music";
     properties_[PA_PROP_APPLICATION_ICON_NAME] = "snapcast";
     if (params.find("property") != params.end())
@@ -349,11 +354,11 @@ void PulsePlayer::writeCallback(pa_stream* stream, size_t nbytes)
     // LOG(TRACE, LOG_TAG) << "writeCallback latency " << usec << " us, frames: " << numFrames << "\n";
     if (!stream_->getPlayerChunkOrSilence(buffer_.data(), std::chrono::microseconds(usec), numFrames))
     {
-        // if we haven't got a chunk for a while, it's time to disconnect from pulse so the sound device
-        // can become idle/suspended.
-        if (chronos::getTickCount() - last_chunk_tick_ > 5000)
+        // if we haven't got a chunk for a while, disconnect from pulse so the sound device
+        // can become idle/suspended. Threshold is configurable via idle_threshold_ms; 0 disables.
+        if (idle_threshold_ > 0s && chronos::getTickCount() - last_chunk_tick_ > idle_threshold_.count())
         {
-            LOG(INFO, LOG_TAG) << "No chunk received for 5000ms, disconnecting from pulse.\n";
+            LOG(INFO, LOG_TAG) << "No chunk received for " << idle_threshold_.count() << "ms, disconnecting from pulse.\n";
             this->disconnect();
             return;
         }

--- a/client/player/pulse_player.hpp
+++ b/client/player/pulse_player.hpp
@@ -77,6 +77,8 @@ private:
     std::atomic<int> pa_ready_;
 
     long last_chunk_tick_;
+    /// Disconnect from pulse after no chunks for this long. 0 = disabled.
+    std::chrono::milliseconds idle_threshold_;
 
     pa_buffer_attr bufattr_;
     pa_sample_spec pa_ss_;

--- a/client/snapclient.cpp
+++ b/client/snapclient.cpp
@@ -500,7 +500,8 @@ int main(int argc, char** argv)
                 cout << "Options are a comma separated list of:\n"
                      << " \"buffer_time=<buffer size [ms]>\" - default 100, min 10\n"
                      << " \"server=<PulseAudio server>\" - default not-set: use the default server\n"
-                     << " \"property=<key>=<value>\" - can be set multiple times, default 'media.role=music'\n";
+                     << " \"property=<key>=<value>\" - can be set multiple times, default 'media.role=music'\n"
+                     << " \"idle_threshold_ms=<ms>\" - disconnect from pulse after no audio for N ms; 0 disables. Default 5000.\n";
             }
 #endif
 #ifdef HAS_ALSA

--- a/client/snapclient.cpp
+++ b/client/snapclient.cpp
@@ -514,8 +514,9 @@ int main(int argc, char** argv)
 #ifdef HAS_PIPEWIRE
             else if (settings.player.player_name == player::PIPEWIRE)
             {
-                cout << "Options are:\n"
-                     << " \"buffer_time=<total buffer size [ms]>\" - default <not set, PipeWire will decide>, min 10\n";
+                cout << "Options are a comma separated list of:\n"
+                     << " \"buffer_time=<total buffer size [ms]>\" - default <not set, PipeWire will decide>, min 10\n"
+                     << " \"idle_threshold_ms=<ms>\" - suspend stream after no audio for N ms; 0 disables. Default 5000.\n";
             }
 #endif
             else


### PR DESCRIPTION
PR #931 (~2021) added the ability for snapclient to disconnect from pulse (issue #927) when there was nothing playing for 5s, allowing pulse to shut down the device, and allowing the device to go to sleep.  The pipewire player has no such support, and so when using pipewire the DAC stays running indefinitely even when nothing is playing.

This PR adds the same feature to the pipewire player: by setting the pipewire stream as inactive, pipewire can then close the underlying alsa device, allowing it to power down, reactivating it as soon as sound arrives again.

The implementation here spawns a small thread when we hit the idle trigger, and that thread blocks pending a condition variable signal for new audio: allowing it to virtually instantly wake up and reactivate the pipewire stream when audio arrives.  This requires some slight reworking of how stop() handles shutdown, to call pw_main_loop_quit directly rather than deferring to onProcess since onProcess doesn't fire when suspended, but the reworking is fairly minimal.

This commit uses `pw_stream_set_active(true/false)` rather than fully closing the stream to avoid the potential wireplumber volume-restoration bug (reported in #1161).  I didn't look into it in much detail, but set_active is sufficient to let the hardware power down, and doesn't seem to hit the reported issue.

My testing with different Raspberry Pis (Zero 2w, 4, 5) with DAC class-D amplifier hats (DigiAMP+ and AMP100s) works with this almost imperceptibly: no perceptible wakeup delay, and at most a tiny click through the speakers when waking up the DAC (although even that isn't always perceptible).

This commit also makes the idle delay configurable, allowing a custom delay to be specified, including allowing 0 to disable it, thus allowing you to keep the stream alive always:

    --player pipewire:idle_threshold_ms=10000

for a 10s idle threshold.  (The default if unspecified is 5s, and 0 disables stream inactivity entirely).

I also added a second commit that ports that same option to the pulse player, `--player pulse:idle_threshold_ms=10000`, with the same ability to set the delay and disable it with `...=0`.

With my Pis I found the reactivation delay miniscule and this allows some power saving by letting the DAC power down when nothing is playing, with barely perceptible wakeup.  On the other hand with other hardware I tried (such as going through HDMI to an Onkyo AV receiver) the delay was an insufferable 3-4s before any sound played at all after activation and so letting a user opt out of this feature seems fairly important.