### PR TITLE
server/tcp: add optional packed s24le ingest for 24-bit streams

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -176,10 +176,14 @@ process:///<path/to/process>?name=<name>[&wd_timeout=0][&log_stderr=false][&para
 Receives audio from a TCP socket (acting as server)
 
 ```sh
-tcp://<listen IP, e.g. 127.0.0.1>:<port>?name=<name>[&mode=server]
+tcp://<listen IP, e.g. 127.0.0.1>:<port>?name=<name>[&mode=server][&packed_s24le=true]
 ```
 
 default for `port` (if omitted) is 4953, default for `mode` is `server`
+
+`packed_s24le=true` can be used for 24-bit streams (`sampleformat=...:24:...`) if the source sends packed
+`s24le` samples (3 bytes/sample), e.g. ffmpeg. Snapserver will convert these samples to its internal 24-bit
+padded-to-32-bit format.
 
 Mopidy configuration would look like this (running GStreamer in [client mode](https://www.freedesktop.org/software/gstreamer-sdk/data/docs/latest/gst-plugins-base-plugins-0.10/gst-plugins-base-plugins-tcpclientsink.html))
 
@@ -193,7 +197,7 @@ output = audioresample ! audioconvert ! audio/x-raw,rate=48000,channels=2,format
 Receives audio from a TCP socket (acting as client)
 
 ```sh
-tcp://<server IP, e.g. 127.0.0.1>:<port>?name=<name>&mode=client
+tcp://<server IP, e.g. 127.0.0.1>:<port>?name=<name>&mode=client[&packed_s24le=true]
 ```
 
 Mopidy configuration would look like this (running GStreamer in [server mode](https://www.freedesktop.org/software/gstreamer-sdk/data/docs/latest/gst-plugins-base-plugins-0.10/gst-plugins-base-plugins-tcpserversink.html)):

--- a/server/streamreader/tcp_stream.cpp
+++ b/server/streamreader/tcp_stream.cpp
@@ -23,12 +23,14 @@
 #include "common/aixlog.hpp"
 #include "common/snap_exception.hpp"
 #include "common/str_compat.hpp"
+#include "common/utils/string_utils.hpp"
 
 // 3rd party headers
 
 // standard headers
 #include <cstdint>
 #include <memory>
+#include <string>
 
 
 using namespace std;
@@ -38,9 +40,33 @@ namespace streamreader
 
 static constexpr auto LOG_TAG = "TcpStream";
 
+namespace
+{
+
+bool getBoolQuery(const StreamUri& uri, const std::string& key, bool fallback = false)
+{
+    auto value = utils::string::tolower_copy(uri.getQuery(key, fallback ? "true" : "false"));
+    return (value == "1") || (value == "true") || (value == "yes") || (value == "on");
+}
+
+void unpackS24LeToS24_32Le(const char* src, char* dst, size_t sample_count)
+{
+    for (size_t idx = 0; idx < sample_count; ++idx)
+    {
+        auto src_idx = idx * 3;
+        auto dst_idx = idx * 4;
+        dst[dst_idx] = src[src_idx];
+        dst[dst_idx + 1] = src[src_idx + 1];
+        dst[dst_idx + 2] = src[src_idx + 2];
+        dst[dst_idx + 3] = (static_cast<unsigned char>(src[src_idx + 2]) & 0x80U) != 0U ? static_cast<char>(0xFF) : 0;
+    }
+}
+
+} // namespace
+
 TcpStream::TcpStream(PcmStream::Listener* pcmListener, boost::asio::io_context& ioc, const ServerSettings& server_settings, const StreamUri& uri,
                      PcmStream::Source source)
-    : AsioStream<tcp::socket>(pcmListener, ioc, server_settings, uri, source), reconnect_timer_(ioc)
+    : AsioStream<tcp::socket>(pcmListener, ioc, server_settings, uri, source), packed_s24le_(false), packed_payload_size_(0), reconnect_timer_(ioc)
 {
     static constexpr uint16_t DEFAULT_PORT = 4953;
     host_ = uri_.host;
@@ -55,6 +81,25 @@ TcpStream::TcpStream(PcmStream::Listener* pcmListener, boost::asio::io_context& 
         throw SnapException("mode must be 'client' or 'server'");
 
     port_ = cpt::stoi(uri_.getQuery("port", cpt::to_string(port_)), port_);
+
+    // Allow ffmpeg-compatible packed 24-bit little endian input on TCP streams.
+    // Snapcast internally uses 24-bit padded to 32-bit words, so convert on ingest.
+    packed_s24le_ = getBoolQuery(uri_, "packed_s24le", false) || getBoolQuery(uri_, "packed_s24", false);
+    if (packed_s24le_)
+    {
+        if (sampleFormat_.bits() != 24)
+        {
+            LOG(WARNING, LOG_TAG) << "packed_s24le=true only applies to 24-bit streams, got sample format: " << sampleFormat_.toString() << "\n";
+            packed_s24le_ = false;
+        }
+        else
+        {
+            packed_payload_size_ = chunk_->getSampleCount() * 3;
+            packed_read_buffer_.resize(packed_payload_size_);
+            LOG(INFO, LOG_TAG) << "Enabled packed_s24le ingest for stream '" << getName() << "', read size: " << packed_payload_size_
+                               << ", chunk size: " << chunk_->payloadSize << "\n";
+        }
+    }
 
     LOG(INFO, LOG_TAG) << "TcpStream host: " << host_ << ", port: " << port_ << ", is server: " << is_server_ << "\n";
     if (is_server_)
@@ -110,6 +155,91 @@ void TcpStream::disconnect()
     if (acceptor_)
         acceptor_->cancel();
     AsioStream<tcp::socket>::disconnect();
+}
+
+void TcpStream::do_read()
+{
+    if (!packed_s24le_)
+    {
+        AsioStream<tcp::socket>::do_read();
+        return;
+    }
+
+    // Reset the silence timer
+    check_state(idle_threshold_ + std::chrono::milliseconds(chunk_ms_));
+    boost::asio::async_read(*stream_, boost::asio::buffer(packed_read_buffer_.data(), packed_payload_size_),
+                            [this, self = shared_from_this()](boost::system::error_code ec, std::size_t length) mutable
+    {
+        state_timer_.cancel();
+
+        if (ec)
+        {
+            if (lastException_ != ec.message())
+            {
+                LOG(ERROR, LOG_TAG) << "Error reading message in stream '" << getName() << "': " << ec.message() << ", length: " << length
+                                    << ", ec: " << ec << "\n";
+                lastException_ = ec.message();
+            }
+            disconnect();
+            wait(read_timer_, 100ms, [this, self = shared_from_this()] { connect(); });
+            return;
+        }
+
+        lastException_.clear();
+        unpackS24LeToS24_32Le(packed_read_buffer_.data(), chunk_->payload, chunk_->getSampleCount());
+
+        if (isSilent(*chunk_))
+        {
+            silence_ += chunk_->duration<std::chrono::microseconds>();
+            if (silence_ >= idle_threshold_)
+            {
+                setState(ReaderState::kIdle);
+                // Avoid overflow
+                silence_ = idle_threshold_;
+            }
+        }
+        else
+        {
+            silence_ = 0ms;
+            setState(ReaderState::kPlaying);
+        }
+
+        if (first_)
+        {
+            first_ = false;
+            tvEncodedChunk_ = std::chrono::steady_clock::now() - chunk_->duration<std::chrono::nanoseconds>();
+            nextTick_ = std::chrono::steady_clock::now();
+        }
+
+        chunkRead(*chunk_);
+        nextTick_ += chunk_->duration<std::chrono::nanoseconds>();
+        auto currentTick = std::chrono::steady_clock::now();
+
+        // Synchronize read to chunk_ms_
+        if (nextTick_ >= currentTick)
+        {
+            read_timer_.expires_after(nextTick_ - currentTick);
+            read_timer_.async_wait([this, self = shared_from_this()](const boost::system::error_code& timer_ec)
+            {
+                if (timer_ec)
+                {
+                    LOG(ERROR, LOG_TAG) << "Error during async wait in stream '" << getName() << "': " << timer_ec.message() << "\n";
+                }
+                else
+                {
+                    do_read();
+                }
+            });
+            return;
+        }
+        // Read took longer, wait for the buffer to fill up
+        else
+        {
+            resync(std::chrono::duration_cast<std::chrono::nanoseconds>(currentTick - nextTick_));
+            first_ = true;
+            do_read();
+        }
+    });
 }
 
 

--- a/server/streamreader/tcp_stream.hpp
+++ b/server/streamreader/tcp_stream.hpp
@@ -25,6 +25,9 @@
 // 3rd party headers
 #include <boost/asio/ip/tcp.hpp>
 
+// standard headers
+#include <vector>
+
 using boost::asio::ip::tcp;
 
 namespace streamreader
@@ -46,10 +49,14 @@ public:
 private:
     void connect() override;
     void disconnect() override;
+    void do_read() override;
     std::unique_ptr<tcp::acceptor> acceptor_;
     std::string host_;
     size_t port_;
     bool is_server_;
+    bool packed_s24le_;
+    size_t packed_payload_size_;
+    std::vector<char> packed_read_buffer_;
     boost::asio::steady_timer reconnect_timer_;
 };
 


### PR DESCRIPTION
## Summary

This PR adds optional support for packed 24-bit PCM (`s24le`, 3 bytes/sample) on TCP stream ingest.

Snapcast currently expects 24-bit PCM as padded 32-bit (`S24_32LE`) internally.  
For ffmpeg-based TCP sources (e.g. Music Assistant), this is a problem because ffmpeg outputs packed `s24le` but not `S24_32LE`.

This addresses [#1518](https://github.com/snapcast/snapcast/issues/1518) and unblocks the Music Assistant flow discussed here: [music-assistant/discussions/3988](https://github.com/orgs/music-assistant/discussions/3988), and [snapcast/snapcast/discussions/1255](https://github.com/snapcast/snapcast/discussions/1255).

### What changed

- Added optional TCP stream URI flag:
  - `packed_s24le=true` (and alias `packed_s24=true`)
- When enabled for a `sampleformat=...:24:...` stream:
  - read packed 3-byte samples from TCP
  - convert to Snapcast internal 24-in-32 representation on ingest
- Left default behavior unchanged when the flag is not set.
- Updated docs in `doc/configuration.md` for TCP server/client source examples.

### Example URI

`tcp://0.0.0.0:4953?name=MusicAssistant&mode=server&sampleformat=96000:24:2&packed_s24le=true`

## Why

This allows ffmpeg-based TCP sources to send 24-bit audio to Snapcast without requiring source-side custom byte-padding logic or switching to larger/heavier alternatives.

## Test plan

Manual testing:

- Built snapserver with this branch and ran with MA TCP source.
- Verified regular TCP streams still work with default settings (no `packed_s24le`).
- Verified stream creation/playback works with `packed_s24le=true` and `sampleformat=...:24:...`.
- Tested playback on multiple clients; successful on desktop + one Raspberry Pi setup.
- On one Raspberry Pi USB DAC path, snapclient initially entered a crash/restart loop when using raw `hw:CARD=Audio,DEV=0`; switching snapclient output to `plughw:CARD=Audio,DEV=0` resolved the loop and playback is stable.
- This indicates the remaining issue is ALSA device/format compatibility on that client path, not TCP ingest parsing.