### PR TITLE
Fix use-after-free in PulsePlayer PulseAudio teardown ordering

### DIFF
--- a/client/player/pulse_player.cpp
+++ b/client/player/pulse_player.cpp
@@ -138,8 +138,8 @@ vector<PcmDevice> PulsePlayer::pcm_list(const std::string& parameter)
 
 
 PulsePlayer::PulsePlayer(boost::asio::io_context& io_context, const ClientSettings::Player& settings, std::shared_ptr<Stream> stream)
-    : Player(io_context, settings, std::move(stream)), latency_(BUFFER_TIME), last_chunk_tick_(0), pa_ml_(nullptr), pa_ctx_(nullptr), playstream_(nullptr),
-      proplist_(nullptr), server_(std::nullopt)
+    : Player(io_context, settings, std::move(stream)), latency_(BUFFER_TIME), pa_ready_(0), disconnect_requested_(false), last_chunk_tick_(0), pa_ml_(nullptr),
+      pa_ctx_(nullptr), playstream_(nullptr), proplist_(nullptr), server_(std::nullopt)
 {
     auto params = utils::string::split_pairs_to_container<std::vector<std::string>>(settings.parameter, ',', '=');
     if (params.find("buffer_time") != params.end())
@@ -185,6 +185,10 @@ void PulsePlayer::worker()
     while (active_)
     {
         pa_mainloop_run(pa_ml_, nullptr);
+        teardown();
+
+        if (!active_)
+            break;
 
         // if we are still active, wait for a chunk and attempt to reconnect
         while (active_ && !stream_->waitForChunk(100ms))
@@ -204,7 +208,7 @@ void PulsePlayer::worker()
             catch (const std::exception& e)
             {
                 LOG(ERROR, LOG_TAG) << "Exception while connecting to pulse: " << e.what() << "\n";
-                disconnect();
+                teardown();
                 chronos::sleep(100);
             }
         }
@@ -343,6 +347,9 @@ void PulsePlayer::writeCallback(pa_stream* stream, size_t nbytes)
     int neg = 0;
     pa_stream_get_latency(stream, &usec, &neg);
 
+    if (disconnect_requested_.load())
+        return;
+
     auto numFrames = nbytes / stream_->getFormat().frameSize();
     if (buffer_.size() < nbytes)
         buffer_.resize(nbytes);
@@ -354,7 +361,7 @@ void PulsePlayer::writeCallback(pa_stream* stream, size_t nbytes)
         if (chronos::getTickCount() - last_chunk_tick_ > 5000)
         {
             LOG(INFO, LOG_TAG) << "No chunk received for 5000ms, disconnecting from pulse.\n";
-            this->disconnect();
+            this->requestDisconnect();
             return;
         }
         // LOG(TRACE, LOG_TAG) << "Failed to get chunk. Playing silence.\n";
@@ -372,7 +379,15 @@ void PulsePlayer::start()
 {
     LOG(INFO, LOG_TAG) << "Start\n";
 
-    this->connect();
+    try
+    {
+        this->connect();
+    }
+    catch (...)
+    {
+        teardown();
+        throw;
+    }
     Player::start();
 }
 
@@ -380,6 +395,7 @@ void PulsePlayer::connect()
 {
     std::lock_guard<std::mutex> lock(mutex_);
     LOG(INFO, LOG_TAG) << "Connecting to pulse\n";
+    disconnect_requested_.store(false);
 
     if (settings_.pcm_device.idx == -1)
         throw SnapException("Can't open " + settings_.pcm_device.name + ", error: No such device");
@@ -513,22 +529,50 @@ void PulsePlayer::stop()
 {
     LOG(INFO, LOG_TAG) << "Stop\n";
 
-    this->disconnect();
-    Player::stop();
+    active_ = false;
+    requestDisconnect();
+    if (playerThread_.joinable())
+        playerThread_.join();
+    teardown();
 }
 
-void PulsePlayer::disconnect()
+void PulsePlayer::requestDisconnect()
 {
     std::lock_guard<std::mutex> lock(mutex_);
-    LOG(INFO, LOG_TAG) << "Disconnecting from pulse\n";
+    disconnect_requested_.store(true);
 
     if (pa_ml_ != nullptr)
     {
         pa_mainloop_quit(pa_ml_, 0);
+        pa_mainloop_wakeup(pa_ml_);
+    }
+}
+
+void PulsePlayer::teardown()
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    LOG(INFO, LOG_TAG) << "Disconnecting from pulse\n";
+
+    disconnect_requested_.store(false);
+    pa_ready_ = 0;
+
+    if (playstream_ != nullptr)
+    {
+        pa_stream_set_state_callback(playstream_, nullptr, nullptr);
+        pa_stream_set_read_callback(playstream_, nullptr, nullptr);
+        pa_stream_set_write_callback(playstream_, nullptr, nullptr);
+        pa_stream_set_underflow_callback(playstream_, nullptr, nullptr);
+        pa_stream_set_overflow_callback(playstream_, nullptr, nullptr);
+
+        pa_stream_disconnect(playstream_);
+        pa_stream_unref(playstream_);
+        playstream_ = nullptr;
     }
 
     if (pa_ctx_ != nullptr)
     {
+        pa_context_set_state_callback(pa_ctx_, nullptr, nullptr);
+        pa_context_set_subscribe_callback(pa_ctx_, nullptr, nullptr);
         pa_context_disconnect(pa_ctx_);
         pa_context_unref(pa_ctx_);
         pa_ctx_ = nullptr;
@@ -538,18 +582,6 @@ void PulsePlayer::disconnect()
     {
         pa_mainloop_free(pa_ml_);
         pa_ml_ = nullptr;
-    }
-
-    if (playstream_ != nullptr)
-    {
-        pa_stream_set_state_callback(playstream_, nullptr, nullptr);
-        pa_stream_set_read_callback(playstream_, nullptr, nullptr);
-        pa_stream_set_underflow_callback(playstream_, nullptr, nullptr);
-        pa_stream_set_overflow_callback(playstream_, nullptr, nullptr);
-
-        pa_stream_disconnect(playstream_);
-        pa_stream_unref(playstream_);
-        playstream_ = nullptr;
     }
 
     if (proplist_ != nullptr)

--- a/client/player/pulse_player.hpp
+++ b/client/player/pulse_player.hpp
@@ -58,7 +58,8 @@ private:
     void worker() override;
 
     void connect();
-    void disconnect();
+    void requestDisconnect();
+    void teardown();
 
     bool getHardwareVolume(Volume& volume) override;
     void setHardwareVolume(const Volume& volume) override;
@@ -75,6 +76,7 @@ private:
     std::chrono::microseconds latency_;
     int underflows_ = 0;
     std::atomic<int> pa_ready_;
+    std::atomic<bool> disconnect_requested_;
 
     long last_chunk_tick_;
 


### PR DESCRIPTION
Fixes #1489.

## Summary

`PulsePlayer::teardown()`'s shutdown order frees the PulseAudio mainloop (`pa_mainloop_free(pa_ml_)`) *before* disconnecting the playback stream and context. `pa_stream_disconnect()`/`pa_context_disconnect()` require the mainloop to still be alive to run cleanly, so this is a use-after-free on Pulse's own internal state. I have direct AddressSanitizer evidence for both this ordering bug specifically and the full RED (unpatched, crashes) -> GREEN (this exact patched diff, survives) pair on the complete production binary under realistic network/reconnect conditions - see the Testing section below.

A secondary, lower-confidence contributing hazard (not independently ASan-isolated on its own, so flagged separately rather than claimed as proven): `writeCallback()` calls `disconnect()` from *inside* libpulse's own `pa_mainloop_run()` dispatch, on the same thread actively running that dispatch loop, so the free happens reentrantly while libpulse's own callback machinery may still reference the torn-down objects.

## Root cause

```text
==1087438==ERROR: AddressSanitizer: SEGV on unknown address 0x0001000005f3
    #2 0x7f80793300 in pa_stream_disconnect (/lib/aarch64-linux-gnu/libpulse.so.0+0x33300)
    #3 0x55746d24d0 in player::PulsePlayer::teardown() .../pulse_player.cpp:571
    #4 0x55746d29fc in player::PulsePlayer::worker() .../pulse_player.cpp:188
```

Captured on a Raspberry Pi 4 (Debian 13, aarch64) while investigating a `v0.31.0`-era source tree (`cf2be071`); the same unsafe teardown order was still present when preparing this patch against current `develop`.

#1489 independently reported very similar symptoms on a different machine/OS (NixOS, x86_64) via a different trigger (system suspend/resume rather than rapid reconnect churn): the same idle-disconnect log signature (`No chunk received for 5000ms, disconnecting from pulse.`) immediately before the segfault. I am treating that report as strong corroborating evidence, not as direct ASan proof on the same path/environment.

A live production symptom this class of bug produces: I separately captured a real core dump from Debian's stock `snapclient 0.31.0-1` package showing the eventual crash as `malloc_consolidate` heap corruption surfacing much later, during an unrelated `FLAC__stream_decoder_new()` allocation for the next codec header. That's consistent with delayed-detection heap corruption rather than a crash exactly at the point of corruption — source correlation traced the earliest concrete unsafe-lifetime-ordering mechanism back to this same Pulse teardown path, though (to be precise) that specific core does not itself prove the exact corrupting instruction — the ASan repro above is what proves the concrete, deterministic defect.

## Fix

- Split `disconnect()` into `requestDisconnect()` (safe from any context — only `pa_mainloop_quit()` + `pa_mainloop_wakeup()` under the existing mutex, zero frees) and `teardown()` (all frees, corrected order): stream (clear all callbacks including the previously-missing write callback, disconnect, unref) → context (clear state/subscribe callbacks, disconnect, unref) → mainloop (free) → proplist (free).
- `teardown()` is only ever called from `worker()` right after `pa_mainloop_run()` genuinely returns, or from `stop()` after the worker thread has joined — never reentrantly from inside a live Pulse callback.
- Added a `disconnect_requested_` atomic guard checked at the top of `writeCallback()`, so a disconnect already in flight is a no-op instead of racing a second request.
- `start()`'s `connect()` call is now wrapped so a connect failure runs `teardown()` before rethrowing, instead of leaving partially-constructed Pulse state behind.

## Testing

**Full production binary, real server, real network, real Bluetooth output (definitive):** built the complete `snapclient` binary (`-DASAN=ON -DBUILD_WITH_PULSE=ON`, this exact `develop`-rebased diff vs. pristine `develop`), connected each to a real Snapcast server over the real network, routed Pulse output to a real Bluetooth-connected speaker, and repeatedly forced real TCP-level disconnect/reconnect cycles to reproduce the tight reconnect cadence from the original crash log.

- **RED (unpatched):** crashed after ~34 rounds of forced reconnect - `AddressSanitizer: SEGV` inside `pa_pdispatch_run`/`pa_pdispatch_unref` during `pa_mainloop_run()`, in a worker thread spawned directly from `Controller::getNextMessage()`'s message-arrival completion handler recreating the player (`controller.cpp:321` -> `PulsePlayer::start()` -> new worker thread -> crash). This is exactly the `Controller`-driven, message-triggered player-recreation pattern that a `PulsePlayer`-only isolated harness structurally cannot reach.
- **GREEN (this exact patched/rebased/reformatted diff):** identical setup and treatment, run for 70 rounds (2x what RED needed) - zero ASan diagnostics, stayed alive throughout.

Full raw logs (both RED and GREEN, complete and unedited): https://gist.github.com/BrianHeeseIs/0702eed7da67584d5227962fa38089ba

**Automated repro (AddressSanitizer, isolated `PulsePlayer`-only, for a minimal standalone reproducer anyone can run without a full server setup):** a small standalone program using only `PulsePlayer`'s public API against a real local PulseAudio/PipeWire-Pulse server. Source + build/run instructions: https://gist.github.com/BrianHeeseIs/c1ff95c83382c15ba44c75339efb21c9. This isolated version reliably shows GREEN but could not reproduce RED on its own (documented in the PR comments below) - it's included as a lightweight sanity check, not as the primary evidence; the full-binary result above is.

**Manual production validation:** the corrected fix (same logical shape as this diff) was deployed to real production hardware running real `snapclient` traffic (repeated real mute/reconnect/idle cycles over an extended session) with zero crashes, after the same unpatched build crashed reliably under the same conditions.

No existing automated tests cover `client/player/` today (`test/` only exercises server-side/common utility code, and CI doesn't currently provision a PulseAudio server), so this PR doesn't touch `test/`.

## Scope

Touches only `client/player/pulse_player.cpp` and `.hpp`. No behavior change to any other player backend, no new dependencies, no CI changes.

---

*Note: given the depth of investigation already done and an independent user (#1489) already hitting the same symptoms, I'm opening this PR alongside claiming the issue rather than waiting for a separate assignment round-trip — happy to adjust process if you'd prefer otherwise.*


