### PR TITLE
fix(client): announce S24_32LE for 24-bit PipeWire playback

### DIFF
--- a/client/player/pipewire_player.cpp
+++ b/client/player/pipewire_player.cpp
@@ -59,7 +59,7 @@ spa_audio_format sampleFormatToPipeWire(const SampleFormat& format)
     else if (format.bits() == 16)
         return SPA_AUDIO_FORMAT_S16_LE;
     else if ((format.bits() == 24) && (format.sampleSize() == 4))
-        return SPA_AUDIO_FORMAT_S24_LE;
+        return SPA_AUDIO_FORMAT_S24_32_LE;
     else if (format.bits() == 32)
         return SPA_AUDIO_FORMAT_S32_LE;
     else


### PR DESCRIPTION
### Problem

With `--player pipewire` and a 24-bit stream, snapclient plays full-scale noise. `--player alsa` on the same stream plays correctly.

### Cause

Snapcast's 24-bit sample layout is 24 bits padded into a 32-bit word (cf. `SampleFormat::setFormat`).

`sampleFormatToPipeWire` announces `SPA_AUDIO_FORMAT_S24_LE`, but in Simple Plugin API (SPA) that is the **packed 3-byte** layout; the padded one is `SPA_AUDIO_FORMAT_S24_32_LE` (a separate enum value in `spa/param/audio/raw.h`).

PipeWire consequently reads a 4-byte-per-sample buffer at 3 bytes per sample, and alignment recurs only every fourth sample, so three of every four are byte-shifted.

Nothing logs an error: `S24_LE` is a valid format to negotiate, just not the one being written.

The ALSA backend performs the identical-looking mapping (`SND_PCM_FORMAT_S24_LE`, `client/player/alsa_player.cpp`) and is correct, because ALSA uses the opposite convention: `S24_LE` is the padded variant and `S24_3LE` the packed one. The PipeWire backend inherited the spelling along with the opposite meaning (hard to believe ...).

### Evidence

Dumping the running graph while snapclient plays a `48000:24:2` stream with `--player pipewire` shows the negotiated format:

```
id=54 type=Node  Snapcast Snapclient
Format: {"mediaType":"audio","mediaSubtype":"raw","format":"S24LE",
         "rate":48000,"channels":2,"position":["FL","FR"]}
```

`S24LE` is 6 bytes per stereo frame, against a buffer snapclient fills at 8.

With this patch applied, the same node reports `"format": "S24_32LE"`, and the stream that was noise plays correctly.

### Reproduction

1. Any source at 24 bit, e.g. `pipe:///tmp/snapfifo?name=x&sampleformat=48000:24:2`, fed by a writer producing 24-in-32 samples (MPD's `format "48000:24:2"` does this).
2. `snapclient --player pipewire` produces noise.
3. `snapclient --player alsa`, same stream produces correct playback.

### Fix

Announce `SPA_AUDIO_FORMAT_S24_32_LE`. Tested on PipeWire 1.6.8 against a `48000:24:2` pipe source: the node negotiates `S24_32LE` and playback is correct. The 8-, 16- and 32-bit branches are unchanged.
